### PR TITLE
Restore missing @ComposeActionConfirmationDialogCase macro

### DIFF
--- a/Sources/TCAComposer/Macros/ComposeMacros.swift
+++ b/Sources/TCAComposer/Macros/ComposeMacros.swift
@@ -21,6 +21,15 @@ public macro ComposeActionAlertCase(_ name: String = "") =
     module: "TCAComposerMacros", type: "ComposeDirectiveMacro"
   )
 
+/// Specifies the enum to use for the `ConfirmationDialogAction` for a confirmation dialog declared in a ``ComposeReducer(_:children:)`` child.
+///
+/// This is an alternative method of declaring confirmation dialogs
+@attached(peer)
+public macro ComposeActionConfirmationDialogCase(_ name: String = "") =
+#externalMacro(
+  module: "TCAComposerMacros", type: "ComposeDirectiveMacro"
+)
+
 /// Directs ``Composer()`` to generate `CasePath`s on an existing `Action` enum. The macro should only be attached
 /// to an empty `AllCasePaths` struct declaration inside of the `Action`
 @attached(peer)

--- a/Tests/TCAComposerTests/TestReducers.swift
+++ b/Tests/TCAComposerTests/TestReducers.swift
@@ -41,6 +41,44 @@ struct CounterParentWithExistingStateAndAction {
   }
 }
 
+// MARK: Alerts and Confirmation Dialogs
+
+@ComposeReducer(
+  children: [
+    .presentsAlert()
+  ]
+)
+@Composer
+struct PresentsAlertReducer {
+  
+  @ComposeActionAlertCase
+  enum AlertAction {
+    case confirmDelete
+  }
+  
+  @ComposeBody(action: \Action.Cases.alert.confirmDelete)
+  func handleAlert() {}
+  
+}
+
+@ComposeReducer(
+  children: [
+    .presentsConfirmationDialog()
+  ]
+)
+@Composer
+struct PresentsConfirmationDialogReducer {
+  
+  @ComposeActionConfirmationDialogCase
+  enum ConfirmationDialogAction {
+    case confirmDelete
+  }
+  
+  @ComposeBody(action: \Action.Cases.confirmationDialog.confirmDelete)
+  func handleConfirmationDialog() {}
+}
+
+
 // MARK: Navigation Destination
 
 @ComposeReducer(


### PR DESCRIPTION
This restores the @ComposeActionConfirmationDialogCase macro definition that went missing during a previous refactor, as well as a compiled test reducer to catch its absence in the future.
