### PR TITLE
Rename `cases` var accessor to `case` for `ScopeSwitchable` State

### DIFF
--- a/Examples/SyncUps/SyncUps/AppFeature.swift
+++ b/Examples/SyncUps/SyncUps/AppFeature.swift
@@ -94,7 +94,7 @@ struct AppView: View {
     NavigationStack(path: $store.scopes(\.path)) {
       SyncUpsListView(store: store.scopes.syncUpsList)
     } destination: { store in
-      switch store.cases {
+      switch store.case {
       case let .detail(store):
         SyncUpDetailView(store: store)
       case let .meeting(meeting, syncUp: syncUp):

--- a/Sources/TCAComposer/ScopeSwitchable+Store.swift
+++ b/Sources/TCAComposer/ScopeSwitchable+Store.swift
@@ -59,7 +59,7 @@ where
   /// > Note: Generated navigation destination reducers created using `.presentsDestination()` are always ``ScopePathable``
   /// rather than ``ScopeSwitchable`` to support scoping to bindings to be used in presentation modifiers in SwiftUI views.
   ///
-  public var cases: State.AllComposedScopeCases.ScopedState {
+  public var `case`: State.AllComposedScopeCases.ScopedState {
     return State.AllComposedScopeCases.scopedState(store: self)
   }
 }


### PR DESCRIPTION
This is a breaking change.

This change brings TCA Composer's implementation of switching over enumerated State in alignment with the same syntax as the 1.8.0 release of TCA by renaming the`Store` accessor `cases` to `case`. 

This PR does not make use of other features from the TCA 1.8.0 release, but end users can now write View code in the same manner as if they were using the new enumerated Reducer feature from 1.8.0.
