### PR TITLE
Add explicit CasePathable conformance to AllComposedCases.ScopedState

### DIFF
--- a/Sources/TCAComposerMacros/Composer.swift
+++ b/Sources/TCAComposerMacros/Composer.swift
@@ -582,7 +582,7 @@ struct Composer {
       }
 
       @CasePathable
-      \(raw: composition.accessModifier)enum ScopedState {
+      \(raw: composition.accessModifier)enum ScopedState: CasePaths.CasePathable  {
       \(raw: decls.map(\.description).joined(separator: "\n"))
       }
       }

--- a/TCAComposer.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TCAComposer.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "e593aba2c6222daad7c4f2732a431eed2c09bb07",
-        "version" : "1.3.0"
+        "revision" : "b871e5ed11a23e52c2896a92ce2c829982ff8619",
+        "version" : "1.4.2"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
-        "version" : "1.1.0"
+        "revision" : "ee97538f5b81ae89698fd95938896dec5217b148",
+        "version" : "1.1.1"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture",
       "state" : {
-        "revision" : "115fe5af41d333b6156d4924d7c7058bc77fd580",
-        "version" : "1.9.2"
+        "revision" : "1f952d8c69ace5e53bb69a218e6ed00e03a4695c",
+        "version" : "1.11.2"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "3ce83179e5f0c83ad54c305779c6b438e82aaf1d",
-        "version" : "1.2.1"
+        "revision" : "f01efb26f3a192a0e88dcdb7c3c391ec2fc25d9c",
+        "version" : "1.3.0"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "d3a5af3038a09add4d7682f66555d6212058a3c0",
-        "version" : "1.2.2"
+        "revision" : "00bc30ca03f98881329fab7f1bebef8eba472596",
+        "version" : "1.3.1"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-identified-collections",
       "state" : {
-        "revision" : "d1e45f3e1eee2c9193f5369fa9d70a6ddad635e8",
-        "version" : "1.0.0"
+        "revision" : "2f5ab6e091dd032b63dacbda052405756010dc3b",
+        "version" : "1.1.0"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-macro-testing",
       "state" : {
-        "revision" : "90e38eec4bf661ec0da1bbfd3ec507d0f0c05310",
-        "version" : "0.3.0"
+        "revision" : "851c8b6bde2000d8051dc9aca1efee04dcc37411",
+        "version" : "0.4.1"
       }
     },
     {
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-perception",
       "state" : {
-        "revision" : "a5bb578d963fcdbffe4fd56c92b2e222f5b02c8a",
-        "version" : "1.1.2"
+        "revision" : "d3ab98dc2887d1cc3bed676f6fa354da4cb22b3c",
+        "version" : "1.2.4"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "5b0c434778f2c1a4c9b5ebdb8682b28e84dd69bd",
-        "version" : "1.15.4"
+        "revision" : "8ddd519780452729c6634ad6bd0d2595938e9ea3",
+        "version" : "1.16.1"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax",
       "state" : {
-        "revision" : "08a2f0a9a30e0f705f79c9cfaca1f68b71bdc775",
-        "version" : "510.0.0"
+        "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
+        "version" : "510.0.2"
       }
     },
     {
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swiftui-navigation.git",
       "state" : {
-        "revision" : "d9e72f3083c08375794afa216fb2f89c0114f303",
-        "version" : "1.2.1"
+        "revision" : "b7c9a79f6f6b1fefb87d3e5a83a9c2fe7cdc9720",
+        "version" : "1.5.0"
       }
     },
     {
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "b13b1d1a8e787a5ffc71ac19dcaf52183ab27ba2",
-        "version" : "1.1.1"
+        "revision" : "6f30bdba373bbd7fbfe241dddd732651f2fbd1e2",
+        "version" : "1.1.2"
       }
     }
   ],

--- a/Tests/TCAComposerMacroTests/ComposeNavigationPathMacroTests.swift
+++ b/Tests/TCAComposerMacroTests/ComposeNavigationPathMacroTests.swift
@@ -87,7 +87,7 @@ final class ComposeNavigationPathMacroTests: XCTestCase {
             }
 
             @CasePathable
-            enum ScopedState {
+            enum ScopedState: CasePaths.CasePathable  {
 
             }
           }
@@ -180,7 +180,7 @@ final class ComposeNavigationPathMacroTests: XCTestCase {
             }
 
             @CasePathable
-            enum ScopedState {
+            enum ScopedState: CasePaths.CasePathable  {
               case counter(store: Store<Counter.State, Counter.Action>)
             }
           }
@@ -276,7 +276,7 @@ final class ComposeNavigationPathMacroTests: XCTestCase {
             }
 
             @CasePathable
-            enum ScopedState {
+            enum ScopedState: CasePaths.CasePathable  {
               case counter(SomeState)
             }
           }
@@ -375,7 +375,7 @@ final class ComposeNavigationPathMacroTests: XCTestCase {
             }
 
             @CasePathable
-            enum ScopedState {
+            enum ScopedState: CasePaths.CasePathable  {
               case counter(SomeState, other: SomeOtherState)
             }
           }
@@ -491,7 +491,7 @@ final class ComposeNavigationPathMacroTests: XCTestCase {
             }
 
             @CasePathable
-            enum ScopedState {
+            enum ScopedState: CasePaths.CasePathable  {
               case detail(store: Store<SyncUpDetail.State, SyncUpDetail.Action>)
               case meeting(Meeting, syncUp: SyncUp)
               case record(store: Store<RecordMeeting.State, RecordMeeting.Action>)
@@ -588,7 +588,7 @@ final class ComposeNavigationPathMacroTests: XCTestCase {
             }
 
             @CasePathable
-            public enum ScopedState {
+            public enum ScopedState: CasePaths.CasePathable  {
               case counter(store: Store<Counter.State, Counter.Action>)
             }
           }

--- a/Tests/TCAComposerMacroTests/ComposeReducer/EnumReducerTests.swift
+++ b/Tests/TCAComposerMacroTests/ComposeReducer/EnumReducerTests.swift
@@ -56,7 +56,7 @@ final class EnumReducerMacroTests: XCTestCase {
               }
 
               @CasePathable
-              enum ScopedState {
+              enum ScopedState: CasePaths.CasePathable  {
 
               }
           }
@@ -153,7 +153,7 @@ final class EnumReducerMacroTests: XCTestCase {
           }
 
           @CasePathable
-          enum ScopedState {
+          enum ScopedState: CasePaths.CasePathable  {
             case counter1(store: Store<Counter.State, Counter.Action>)
             case counter2(store: Store<Counter.State, Counter.Action>)
             case someState(String)
@@ -266,7 +266,7 @@ final class EnumReducerMacroTests: XCTestCase {
           }
 
           @CasePathable
-          enum ScopedState {
+          enum ScopedState: CasePaths.CasePathable  {
             case counter1(store: Store<Counter.State, Counter.Action>)
             case counter2(store: Store<Counter.State, Counter.Action>)
             case someState(String)
@@ -342,7 +342,7 @@ final class EnumReducerMacroTests: XCTestCase {
           }
 
           @CasePathable
-          enum ScopedState {
+          enum ScopedState: CasePaths.CasePathable  {
             case tupleStateDefault(Int, String)
           }
         }

--- a/Tests/TCAComposerMacroTests/ComposeReducer/EnumeratedReducerOptionTests.swift
+++ b/Tests/TCAComposerMacroTests/ComposeReducer/EnumeratedReducerOptionTests.swift
@@ -64,7 +64,7 @@ final class EnumeratedReducerOptionTests: XCTestCase {
           }
 
           @CasePathable
-          enum ScopedState {
+          enum ScopedState: CasePaths.CasePathable  {
             case emptyState
           }
         }
@@ -136,7 +136,7 @@ final class EnumeratedReducerOptionTests: XCTestCase {
           }
 
           @CasePathable
-          enum ScopedState {
+          enum ScopedState: CasePaths.CasePathable  {
             case feature(store: Store<Feature.State, Feature.Action>)
           }
         }


### PR DESCRIPTION
Fixes missing protocol witness table macro bug, that appears with changes introduced in swift-case-paths 1.4.0